### PR TITLE
fix: ensure transaction description is dynamically sourced from data

### DIFF
--- a/src/app/api/databases/transactions.ts
+++ b/src/app/api/databases/transactions.ts
@@ -16,7 +16,7 @@ export const transactions = [
     types: TRANSACTION_TYPES.OUTFLOW,
     created_at: new Date(),
     source: TRANSACTION_SOURCES.CARD,
-    subject: '',
+    description: 'Deposit from my Card',
   },
   {
     id: 2,
@@ -24,7 +24,7 @@ export const transactions = [
     types: TRANSACTION_TYPES.INFLOW,
     created_at: new Date(),
     source: TRANSACTION_SOURCES.PAYPAL,
-    subject: '',
+    description: 'Deposit Paypal',
   },
   {
     id: 3,
@@ -32,7 +32,7 @@ export const transactions = [
     types: TRANSACTION_TYPES.INFLOW,
     created_at: new Date(),
     source: TRANSACTION_SOURCES.OTHERS,
-    subject: 'Jemi Wilson',
+    description: 'Jemi Wilson',
   },
   {
     id: 4,
@@ -40,6 +40,6 @@ export const transactions = [
     types: TRANSACTION_TYPES.OUTFLOW,
     created_at: new Date(),
     source: TRANSACTION_SOURCES.OTHERS,
-    subject: 'Someone Else',
+    description: 'Someone Else',
   },
 ];

--- a/src/app/dashboard/TransactionsList/TransactionItem.tsx
+++ b/src/app/dashboard/TransactionsList/TransactionItem.tsx
@@ -8,7 +8,7 @@ import { TRANSACTION_SOURCES, TRANSACTION_TYPES } from '@/types/dashboard';
 import dayjs from 'dayjs';
 
 type TransactionItemProps = {
-  subject: string;
+  description: string;
   amount: number;
   types: keyof typeof TRANSACTION_TYPES;
   date: string;
@@ -16,7 +16,7 @@ type TransactionItemProps = {
 };
 
 export default function TransactionItem(props: TransactionItemProps) {
-  const { amount, types, date, source, subject } = props;
+  const { amount, types, date, source, description } = props;
 
   const _icon = useMemo(() => {
     switch (source) {
@@ -36,31 +36,20 @@ export default function TransactionItem(props: TransactionItemProps) {
     return 'text-leaf-green';
   }, [types]);
 
-  const _title = useMemo(() => {
-    switch (source) {
-      case TRANSACTION_SOURCES.CARD:
-        return 'Deposit from my Card';
-      case TRANSACTION_SOURCES.PAYPAL:
-        return 'Deposit Paypal';
-      default:
-        return subject;
-    }
-  }, [source, subject]);
-
   return (
     <div
       className="flex items-center gap-5"
       role="listitem"
-      aria-labelledby={`transaction-${_title}`}
+      aria-labelledby={`transaction-${description}`}
     >
       <Image src={_icon} alt="Card Transaction" width={55} height={55} />
       <div className="flex-[2]">
         <Text
           variant={TEXT_VARIANTS.BODY}
           className="text-charcoal"
-          id={`transaction-${_title}`}
+          id={`transaction-${description}`}
         >
-          {_title}
+          {description}
         </Text>
         <Text variant={TEXT_VARIANTS.BODY} className="text-night-charcoal">
           {dayjs(date).format('DD MMMM YYYY')}

--- a/src/app/dashboard/TransactionsList/index.tsx
+++ b/src/app/dashboard/TransactionsList/index.tsx
@@ -30,7 +30,7 @@ export default function TransactionList({
                 types={transaction.types}
                 date={transaction.created_at}
                 source={transaction.source}
-                subject={transaction.subject}
+                description={transaction.description}
               />
             </li>
           );

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -24,7 +24,7 @@ export interface RecentTransactions {
   types: keyof typeof TRANSACTION_TYPES;
   created_at: string;
   source: keyof typeof TRANSACTION_SOURCES;
-  subject: string;
+  description: string;
 }
 
 export interface WeeklyActivities {


### PR DESCRIPTION
Previously, the transaction description was incorrectly treated as a static title based on the transaction type. This fix ensures the description is now dynamically fetched from the provided data.